### PR TITLE
NSUrlSessionHandler: TimeoutInterval to TotalSeconds rather than Seconds

### DIFF
--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -131,7 +131,7 @@ namespace ModernHttpClient
             };
 
             if (Timeout != null)
-                rq.TimeoutInterval = Timeout.Value.Seconds;
+                rq.TimeoutInterval = Timeout.Value.TotalSeconds;
 
             var op = session.CreateDataTask(rq);
 


### PR DESCRIPTION
The setting of:

rq.TimeoutInterval = Timeout.Value.Seconds;

Should be:

rq.TimeoutInterval = Timeout.Value.TotalSeconds;

so that the TimeoutInterval is set to the TimeSpan in seconds rather than the seconds part of the Timespan which would be zero for any whole minute.